### PR TITLE
Conexion usando sqlite en memoria

### DIFF
--- a/src/utn111/pizzeria/db/Conexion.java
+++ b/src/utn111/pizzeria/db/Conexion.java
@@ -5,19 +5,16 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public class Conexion {
+
   private final Connection cnn;
-  
+
+  private Conexion(Connection cnn) {
+    this.cnn = cnn;
+  }
+
   public Conexion(String host, String user, String pass) {
     try {
       cnn = DriverManager.getConnection(host, user, pass);
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
-    }
-  }
-  
-  public Conexion(String host) {
-    try {
-      cnn = DriverManager.getConnection(host);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
@@ -30,4 +27,25 @@ public class Conexion {
   public int execute(String sql) {
     return preparar(sql).execute();
   }
+
+  /**
+   * Crea una conexion sqlite en memoria
+   *
+   * Necesita el jar del conector de sqlite para funcionar correctamente
+   *
+   * @link https://bitbucket.org/xerial/sqlite-jdbc/downloads/
+   */
+  public static Conexion sqlite() {
+    try {
+      return new Conexion(withSqlite());
+    }
+    catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static Connection withSqlite() throws SQLException {
+    return DriverManager.getConnection("jdbc:sqlite::memory:");
+  }
+
 }

--- a/src/utn111/pizzeria/db/Conexion.java
+++ b/src/utn111/pizzeria/db/Conexion.java
@@ -36,16 +36,16 @@ public class Conexion {
    * @link https://bitbucket.org/xerial/sqlite-jdbc/downloads/
    */
   public static Conexion sqlite() {
+    return new Conexion(withSqlite());
+  }
+
+  static Connection withSqlite() {
     try {
-      return new Conexion(withSqlite());
+      return DriverManager.getConnection("jdbc:sqlite::memory:");
     }
     catch (SQLException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  static Connection withSqlite() throws SQLException {
-    return DriverManager.getConnection("jdbc:sqlite::memory:");
   }
 
 }

--- a/test/utn111/pizzeria/db/ConexionTest.java
+++ b/test/utn111/pizzeria/db/ConexionTest.java
@@ -1,5 +1,9 @@
 package utn111.pizzeria.db;
 
+import static org.junit.Assert.assertNotNull;
+
+import java.sql.Connection;
+
 import org.junit.Test;
 import utn111.pizzeria.db.Conexion;
 
@@ -9,7 +13,7 @@ public class ConexionTest {
    * Pruebo una conexion con una BD en memoria.
    */
   @Test public void testUnaConexion() {
-    Conexion c = Conexion.sqlite();
-    c.preparar("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float)");
+    Connection cnn = Conexion.withSqlite();
+    assertNotNull(cnn);
   }
 }

--- a/test/utn111/pizzeria/db/ConexionTest.java
+++ b/test/utn111/pizzeria/db/ConexionTest.java
@@ -9,8 +9,7 @@ public class ConexionTest {
    * Pruebo una conexion con una BD en memoria.
    */
   @Test public void testUnaConexion() {
-    final String host = "jdbc:sqlite::memory:";
-    Conexion c = new Conexion(host);
+    Conexion c = Conexion.sqlite();
     c.preparar("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float)");
   }
 }

--- a/test/utn111/pizzeria/db/ConsultaTest.java
+++ b/test/utn111/pizzeria/db/ConsultaTest.java
@@ -2,95 +2,96 @@ package utn111.pizzeria.db;
 
 import static org.junit.Assert.assertEquals;
 import java.sql.Connection;
-import java.sql.DriverManager;
+import java.sql.SQLException;
+
 import org.junit.Test;
 import utn111.pizzeria.db.Consulta;
 
 public class ConsultaTest {
   // Pruebo consultas con sentencias sql correctas
-  @Test public void testConsultaInsert() throws Exception {
+  @Test public void testConsultaInsert() {
     Consulta c = consulta("INSERT INTO Tipos VALUES ('d', 4, 44), ('e', 5, 55)");
     assertEquals(2, c.execute());
   }
 
-  private Consulta consulta(String sql) throws Exception {
-    return new Consulta(bd(), sql);
+  private Consulta consulta(String sql) {
+    return new Consulta(connection(), sql);
   }
   
-  @Test public void testConsultaDelete() throws Exception {
+  @Test public void testConsultaDelete() {
     Consulta c = consulta("DELETE FROM Tipos WHERE numero=1");
     assertEquals(1, c.execute());
   }
   
-  @Test public void testConsultaUpdate() throws Exception {
+  @Test public void testConsultaUpdate() {
     Consulta c = consulta("UPDATE Tipos SET texto = 'a' WHERE numero=2");
     assertEquals(1, c.execute());
   }
   
-  @Test public void testConsultaSelect() throws Exception {
+  @Test public void testConsultaSelect() {
     Consulta c = consulta("SELECT * FROM Tipos");
     c.select();
   }
   
   // Pruebo consultas con excepciones
   @Test (expected = RuntimeException.class)
-  public void testExecute() throws Exception {
+  public void testExecute() {
     Consulta c = consulta("SELECT * FROM Tipos");
     c.execute();
   }
   
   @Test (expected = RuntimeException.class)
-  public void testSelect() throws Exception {
+  public void testSelect() {
     Consulta c = consulta("UPDATE Tipos SET texto = 'a' WHERE numero = 2");
     c.select();
   }
   
   @Test (expected = RuntimeException.class)
-  public void testParam() throws Exception {
+  public void testParam() {
     Consulta c = consulta("UPDATE Tipos SET texto = a WHERE numero = ?");
     c.param(1, 2);
     c.execute();
   }
   
   // Pruebo consultas con parametros usando posicion
-  @Test public void testConsultaParam() throws Exception {
+  @Test public void testConsultaParam() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ?");
     c.param(1, "o");
     assertEquals(0, c.execute());
   }
   
-  @Test public void testConsultaParamExcepcion() throws Exception {
+  @Test public void testConsultaParamExcepcion() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ?");
     c.param(1, "a");
     assertEquals(1, c.execute());
   }
   
-  @Test public void testConsultaParamExcepcion3() throws Exception {
+  @Test public void testConsultaParamExcepcion3() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ?");
     c.param(1, "o");
     assertEquals(0, c.execute());
   }
   
-  @Test public void testConsultaVariosParam() throws Exception {
+  @Test public void testConsultaVariosParam() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ? OR numero = ?");
     c.param(1, "c");
     c.param(2, 2);
     assertEquals(2, c.execute());
   }
   
-  @Test public void testConsultaParamExcepcion1() throws Exception {
+  @Test public void testConsultaParamExcepcion1() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ?");
     c.param("a");
     assertEquals(1, c.execute());
   }
   
-  @Test public void testConsultaParamExcepcion2() throws Exception {
+  @Test public void testConsultaParamExcepcion2() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ?");
     c.param("o");
     assertEquals(0, c.execute());
   }
   
-  @Test public void testConsultaVariosParam2() throws Exception {
+  @Test public void testConsultaVariosParam2() {
     Consulta c = consulta("DELETE FROM Tipos WHERE texto = ? OR numero = ?");
     c.param("c");
     c.param(2);
@@ -102,11 +103,15 @@ public class ConsultaTest {
    *
    * @return Conexion con la BD preparada.
    */
-  public Connection bd() throws Exception {
-    final String host = "jdbc:sqlite::memory:";
-    Connection cnn = DriverManager.getConnection(host);
-    cnn.prepareStatement("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float);").execute();
-    cnn.prepareStatement("INSERT INTO Tipos VALUES ('a', 1, 11), ('b', 2, 22), ('c', 3, 33)").execute();
+  public Connection connection() {
+    Connection cnn = Conexion.withSqlite();
+    try {
+      cnn.prepareStatement("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float);").execute();
+      cnn.prepareStatement("INSERT INTO Tipos VALUES ('a', 1, 11), ('b', 2, 22), ('c', 3, 33)").execute();
+    }
+    catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
     return cnn;
   }
 }

--- a/test/utn111/pizzeria/db/ResultadosTest.java
+++ b/test/utn111/pizzeria/db/ResultadosTest.java
@@ -1,10 +1,10 @@
 package utn111.pizzeria.db;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 import java.sql.Connection;
-import java.sql.DriverManager;
+
 import org.junit.Test;
-import utn111.pizzeria.db.Resultados;
 
 public class ResultadosTest {
 
@@ -127,8 +127,7 @@ public class ResultadosTest {
    * @return Resultado de una query
    */
   public Resultados resultados() throws Exception {
-    final String host = "jdbc:sqlite::memory:";
-    Connection cnn = DriverManager.getConnection(host);
+    Connection cnn = Conexion.withSqlite();
     cnn.prepareStatement("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float, booleano bit);").execute();
     cnn.prepareStatement("INSERT INTO Tipos VALUES ('a', 1, 11, 1)").execute();
     return new Resultados(cnn.prepareStatement("SELECT * FROM Tipos").executeQuery());

--- a/test/utn111/pizzeria/db/ResultadosTest.java
+++ b/test/utn111/pizzeria/db/ResultadosTest.java
@@ -3,6 +3,7 @@ package utn111.pizzeria.db;
 import static org.junit.Assert.assertEquals;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 import org.junit.Test;
 
@@ -10,126 +11,129 @@ public class ResultadosTest {
 
   private static final float e = (float) 1e-10;
 
-  @Test public void testHashNext() throws Exception {
+  @Test public void testHashNext()  {
     assertEquals(true, resultados().hashNext());
   }
   
-  @Test public void testNext() throws Exception {
+  @Test public void testNext() {
     assertEquals(false, resultados().next());
   }
   
-  @Test public void testHashNextFalse() throws Exception {
+  @Test public void testHashNextFalse() {
     Resultados r = resultados();
     r.next();
     r.next();
     assertEquals(false, r.hashNext());
   }
   
-  @Test public void testNextFalse() throws Exception {
+  @Test public void testNextFalse() {
     Resultados r = resultados();
     r.next();
     assertEquals(false, r.next());
   }
   
   // Pruebo Metodos de Lectura de Datos Correctos
-  @Test public void testGetBooleanNombreTabla() throws Exception {
+  @Test public void testGetBooleanNombreTabla() {
     assertEquals(true, resultados().getBoolean("booleano"));
   }
   
-  @Test public void testGetBooleanNumTabla() throws Exception {
+  @Test public void testGetBooleanNumTabla() {
     assertEquals(true, resultados().getBoolean(4));
   }
   
-  @Test public void testGetIntNombreTabla() throws Exception {
+  @Test public void testGetIntNombreTabla() {
     assertEquals(1, resultados().getInteger("numero"));
   }
   
-  @Test public void testGetIntNumTabla() throws Exception {
+  @Test public void testGetIntNumTabla() {
     assertEquals(1, resultados().getInteger(2));
   }
   
-  @Test public void testGetFloatNombreTabla() throws Exception {
+  @Test public void testGetFloatNombreTabla() {
     assertEquals(11, resultados().getFloat("flotante"), e);
   }
   
-  @Test public void testGetFloatNumTabla() throws Exception {
+  @Test public void testGetFloatNumTabla() {
     assertEquals(11, resultados().getFloat(3), e);
   }
   
-  @Test public void testGetStringNombreTabla() throws Exception {
+  @Test public void testGetStringNombreTabla() {
     Resultados r = resultados();
     assertEquals("a", r.getString("texto"));
   }
   
-  @Test public void testGetStringNumTabla() throws Exception {
+  @Test public void testGetStringNumTabla() {
     assertEquals("a", resultados().getString(1));
   }
   
   // Pruebo Metodos de Lectura de Datos Con Errores
   @Test
-  public void testGetBooleanError() throws Exception {
+  public void testGetBooleanError() {
     Boolean resultado = resultados().getBoolean("texto");
     assertEquals(false, resultado);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetBooleanExcepcion() throws Exception {
+  public void testGetBooleanExcepcion() {
     resultados().getBoolean("boolea");
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetStringError() throws Exception {
+  public void testGetStringError() {
     resultados().getString(2);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetStringErrorColumna() throws Exception {
+  public void testGetStringErrorColumna() {
     resultados().getString(100);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetStringExcepcion() throws Exception {
+  public void testGetStringExcepcion() {
     resultados().getString("cosa");
   }
   
   @Test (expected = IllegalArgumentException.class)
-  public void testGetIntegerError() throws Exception{
+  public void testGetIntegerError() {
     resultados().getInteger(1);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetIntegerErrorColumna() throws Exception{
+  public void testGetIntegerErrorColumna() {
     resultados().getInteger(100);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetIntegerExcepcion() throws Exception {
+  public void testGetIntegerExcepcion() {
     resultados().getInteger("num");
   }
   
   @Test (expected = IllegalArgumentException.class)
-  public void testGetFloatError() throws Exception{
+  public void testGetFloatError() {
     resultados().getFloat(1);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetFloatErrorColumna() throws Exception{
+  public void testGetFloatErrorColumna() {
     resultados().getFloat(100);
   }
   
   @Test (expected = RuntimeException.class)
-  public void testGetFloatExcepcion() throws Exception {
+  public void testGetFloatExcepcion() {
     resultados().getFloat("flot");
   }
+
   /**
-   * Creo una BD en memoria
-   *
-   * @return Resultado de una query
+   * @return Resultados de una query
    */
-  public Resultados resultados() throws Exception {
+  public Resultados resultados() {
     Connection cnn = Conexion.withSqlite();
-    cnn.prepareStatement("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float, booleano bit);").execute();
-    cnn.prepareStatement("INSERT INTO Tipos VALUES ('a', 1, 11, 1)").execute();
-    return new Resultados(cnn.prepareStatement("SELECT * FROM Tipos").executeQuery());
+    try {
+      cnn.prepareStatement("CREATE TABLE Tipos(texto varchar(40), numero int, flotante float, booleano bit);").execute();
+      cnn.prepareStatement("INSERT INTO Tipos VALUES ('a', 1, 11, 1)").execute();
+      return new Resultados(cnn.prepareStatement("SELECT * FROM Tipos").executeQuery());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
Agrego un metodo en `Conexion` para conectarse a sqlite en memoria, asi no lo repetimos en todos los tests.

cc @cristianaltamirano @pablopetito 